### PR TITLE
Fix delete book functionality to account for swap conflicts.

### DIFF
--- a/public/scripts/account.js
+++ b/public/scripts/account.js
@@ -236,4 +236,4 @@ for (var i = 0; i < cancels.length; i++) {
 	cancels[i].addEventListener("click", cancelUpdate);
 }
 
-window.onload = document.getElementById("booksTab").click();
+window.onload = document.getElementById("profileTab").click();

--- a/src/models/swap.js
+++ b/src/models/swap.js
@@ -27,7 +27,6 @@ Swap.createSwap = function(info) {
     return mysql.query(getQuery("createSwap"), [info.list_id, info.traded_to, info.traded_by, new Date()]);
 };
 
-
 Swap.acceptSwap = function(swapId, date) {
     return mysql.query(getQuery("acceptSwap"), [new Date(), swapId]);
 };
@@ -81,12 +80,15 @@ Swap.deleteSwap = function(id) {
 };
 
 Swap.getTradedById = function(swapId) {
-    console.log("swapID: ", swapId);
     return mysql.query(getQuery("getTradedById"), [swapId]);
 }
 
 Swap.getTradedToId = function(swapId) {
     return mysql.query(getQuery("getTradedToId"), [swapId]);
+}
+
+Swap.deleteSwapsByListId = function(list_id) {
+    return mysql.query(getQuery("deleteSwapsByListId"), [list_id.list_id]);
 }
 
 function getQuery(type) {
@@ -172,6 +174,9 @@ function getQuery(type) {
                     INNER JOIN books_owned AS bo ON s.list_id = bo.list_id \
                     INNER JOIN book_condition AS bc ON bo.condition_id = bc.condition_id \
                     WHERE swap_id = ?;";
+            break;
+        case "deleteSwapsByListId":
+            query = "DELETE FROM swap WHERE list_id = ?;";
             break;
     }
 

--- a/src/services/account.js
+++ b/src/services/account.js
@@ -2,7 +2,8 @@ var UserModel = require("../models/user"),
     BooksOwnedModel = require("../models/books_owned"),
     WishListModel = require("../models/wishlist"),
     SwapServices = require("./swap"),
-    BookModel = require("../models/book");
+    BookModel = require("../models/book"),
+    SwapModel = require("../models/swap"),
     AlertServices = require("./alert");
 var AccountServices = {};
 
@@ -103,7 +104,8 @@ AccountServices.updateCondition = function(info) {
 
 AccountServices.deleteBooks = function(list_id, user_id) {
     var p1 = new Promise(function(resolve, reject) {
-        BooksOwnedModel.deleteBook(list_id)
+        SwapModel.deleteSwapsByListId(list_id)
+            .then(BooksOwnedModel.deleteBook(list_id))
             .then(resolve)
             .catch(reject);
         });
@@ -112,7 +114,6 @@ AccountServices.deleteBooks = function(list_id, user_id) {
             .then(resolve)
             .catch(reject);
         });
-
     return Promise.all([p1, p2]);
 };
 


### PR DESCRIPTION
**Story:**  N/A
**Updates:**
- Fixes delete books_owned functionality to account for instance where a foreign key constraint conflict exists with the swap table.
- Account page defaults to profile tab on user dashboard upon load.