### PR TITLE
add checkbox to keep email private for account

### DIFF
--- a/public/views/manageaccount.handlebars
+++ b/public/views/manageaccount.handlebars
@@ -18,6 +18,10 @@
             <P></P>
             <input type="text" name="zip" value="{{zip}}" required>
             <P></P>
+            <input type="hidden" name ="private" value="0">
+            <input type="checkbox" name="private" value="1" {{private}}
+            <label for="private">Hide email from other users</label>
+            <P></P>
             <input type="reset" name="resetManageBtn" value="reset!" class="details btn btn-primary">
             <input type="submit" name="editBtn" value="finish changes!" class="details btn btn-primary">
         </form>
@@ -82,5 +86,3 @@
         </div>
     </div>
 </div>
-
-<script src="../scripts/manageaccount.js"></script>

--- a/src/api/account.js
+++ b/src/api/account.js
@@ -162,6 +162,11 @@ router.route("/manage")
     .get(function(req, res, next) {
         UserServices.getUserById(req.session.u_id)
         .then(function(user) {
+            if (user[0].private == 1) {
+                user[0].private = "checked";
+            } else {
+                user[0].private = "";
+            }
             res.render("manageaccount", user[0])
         })
         .catch(function(err) {

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -45,7 +45,7 @@ User.updatePoints = function(amount, user_id) {
 User.updateUser = function(user) {
     return mysql.query(getQuery("updateUser"), 
     [user.first_name, user.last_name, user.email, user.street, user.city,
-        user.state, user.zip, user.user_id]);
+        user.state, user.zip, user.private, user.user_id]);
 }
 
 User.updatePassword = function(user_id, password) {
@@ -88,7 +88,7 @@ function getQuery(type) {
 
         case "updateUser":
             query = "UPDATE user SET first_name = ?, last_name = ?, email = ?, street = ?, \
-            city = ?, state = ?, zip = ? WHERE user_id = ?";
+            city = ?, state = ?, zip = ?, private = ? WHERE user_id = ?";
             break;
         
         case "updatePassword":

--- a/src/services/account.js
+++ b/src/services/account.js
@@ -124,6 +124,9 @@ AccountServices.deleteWish = function(user_id, book_id) {
 
 AccountServices.updateAccount = function(user) {
     return new Promise(function(resolve, reject) {
+        if (user.private.length > 1) {
+            user.private = user.private[1];
+        }
         UserModel.updateUser(user)
             .then(resolve)
             .catch(reject);


### PR DESCRIPTION
Update:

- Add checkbox to keep email hidden in account
- Update queries to include privacy field

Note:
- 'private' field in user table is now active as a boolean